### PR TITLE
Fixed import statement for nuxt v1.0.0-rc2

### DIFF
--- a/template/pages/index.vue
+++ b/template/pages/index.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import Logo from '~components/Logo.vue'
+import Logo from '~/components/Logo.vue'
 
 export default {
   components: {


### PR DESCRIPTION
In nuxt version v1.0.0-rc2 using the alias ~ for importing components stopped to work when running dev, build or generate. Using ~/ instead fixed the issue.