### PR TITLE
Fixing isDev deprecation warning

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -25,7 +25,7 @@ module.exports = {
     ** Run ESLint on save
     */
     extend (config, ctx) {
-      if (ctx.dev && ctx.isClient) {
+      if (ctx.isDev && ctx.isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,


### PR DESCRIPTION
Fixes the `dev has been deprecated in build.extend(), please use isDev` warning in the building stage.