### PR TITLE
Remove line break in package.json

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -23,4 +23,3 @@
     "eslint-plugin-vue": "^4.0.0"
   }
 }
-


### PR DESCRIPTION
After creating the project in `vue init nuxt-community/starter-template`,
if you run `npm install`, `npm` formats `package.json` and removes the last line break.
Because it is removed by `npm`, I think that it is better not to have the last line break.