### PR TITLE
Fix eslint error

### DIFF
--- a/template/nuxt.config.js
+++ b/template/nuxt.config.js
@@ -24,8 +24,8 @@ module.exports = {
     /*
     ** Run ESLint on save
     */
-    extend (config, { isDev, isClient }) {
-      if (isDev && isClient) {
+    extend (config, { isDev }) {
+      if (isDev && process.isClient) {
         config.module.rules.push({
           enforce: 'pre',
           test: /\.(js|vue)$/,


### PR DESCRIPTION
Fix the following error
using node v8.12.0 (npm v6.4.1), vue 3.04
```
vue init nuxt-community/starter-template test
cd test
npm install 
npm run dev 
```
error appears  : 
ERROR  Failed to compile with 1 errors                                                                                                                                 17:53:05

Module build failed (from ./node_modules/eslint-loader/index.js):
TypeError: Cannot read property 'eslint' of undefined
    at Object.module.exports (/Users/fbernard/tmp/test/node_modules/eslint-loader/index.js:148:18)

You may use special comments to disable some warnings.
Use // eslint-disable-next-line to ignore the next line.
Use /* eslint-disable */ to ignore all warnings in a file.