### PR TITLE
fix: update deps to fix eslint issue

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -16,10 +16,10 @@
     "nuxt": "^2.0.0"
   },
   "devDependencies": {
-    "babel-eslint": "^8.2.1",
-    "eslint": "^4.15.0",
-    "eslint-friendly-formatter": "^3.0.0",
-    "eslint-loader": "^1.7.1",
+    "babel-eslint": "^10.0.1",
+    "eslint": "^4.19.1",
+    "eslint-friendly-formatter": "^4.0.1",
+    "eslint-loader": "^2.1.1",
     "eslint-plugin-vue": "^4.0.0"
   }
 }


### PR DESCRIPTION
Fix issue #82 on build.
Related to PR https://github.com/nuxt-community/starter-template/pull/85.

```sh
 ERROR  Failed to compile with 1 errors                                                                                                                                                           1:55:21 PM

Module build failed (from ./node_modules/eslint-loader/index.js):
TypeError: Cannot read property 'eslint' of undefined
    at Object.module.exports (/Users/npennec/dev/perso/github/nuxt-test/node_modules/eslint-loader/index.js:148:18)
```